### PR TITLE
Store keys per XMTP environment

### DIFF
--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -620,7 +620,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"xmtp-inbox-ios/Preview Content\"";
 				DEVELOPMENT_TEAM = FY4NZR34Z3;
@@ -664,7 +664,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"xmtp-inbox-ios/Preview Content\"";
 				DEVELOPMENT_TEAM = FY4NZR34Z3;

--- a/xmtp-inbox-ios/Info.plist
+++ b/xmtp-inbox-ios/Info.plist
@@ -17,5 +17,7 @@
 	</array>
 	<key>INFURA_KEY</key>
 	<string>$(INFURA_KEY)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
I noticed when switching between `dev` and `production` builds the keys were shared between environments because they were stored per account address. This PR updates the keys to be stored per environment + account address so we can switch between environments without issues.

I also updated the requirement for keys to have the device unlocked to only require one unlock after device reboot because it will be necessary for background push notifications soon.
