### PR TITLE
Add relative timestamps to conversation list

### DIFF
--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		6A4613192982080E00346D68 /* AlertExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4613182982080E00346D68 /* AlertExtensions.swift */; };
 		6A46131B2982118500346D68 /* ErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A46131A2982118500346D68 /* ErrorViewModel.swift */; };
 		6A46132929831BD800346D68 /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A46132829831BD800346D68 /* AccountView.swift */; };
+		6A5DA48A298C03A700CEA7CD /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5DA489298C03A700CEA7CD /* DateExtensions.swift */; };
+		6A5DA48C298C113400CEA7CD /* .swiftformat in Resources */ = {isa = PBXBuildFile; fileRef = 6A5DA48B298C113400CEA7CD /* .swiftformat */; };
 		6AA65965297B2A2200E980AD /* WalletConnectSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6AA65964297B2A2200E980AD /* WalletConnectSwift */; };
 		6AA65968297B2A7100E980AD /* WalletConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA65967297B2A7100E980AD /* WalletConnection.swift */; };
 		6AA6596B297B2DB000E980AD /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA6596A297B2DB000E980AD /* Account.swift */; };
@@ -95,6 +97,8 @@
 		6A4613182982080E00346D68 /* AlertExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertExtensions.swift; sourceTree = "<group>"; };
 		6A46131A2982118500346D68 /* ErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewModel.swift; sourceTree = "<group>"; };
 		6A46132829831BD800346D68 /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
+		6A5DA489298C03A700CEA7CD /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
+		6A5DA48B298C113400CEA7CD /* .swiftformat */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftformat; sourceTree = "<group>"; };
 		6AA65967297B2A7100E980AD /* WalletConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnection.swift; sourceTree = "<group>"; };
 		6AA65969297B2C4000E980AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6AA6596A297B2DB000E980AD /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
@@ -149,6 +153,7 @@
 		6A40153A29526795003A6659 = {
 			isa = PBXGroup;
 			children = (
+				6A5DA48B298C113400CEA7CD /* .swiftformat */,
 				A663399E2989CF1600477E2E /* Secrets.xcconfig */,
 				A682B1E8298B071800121651 /* ci_scripts */,
 				6AE264E52973D3CD0055250A /* README.md */,
@@ -243,6 +248,7 @@
 				6A40157E2952B237003A6659 /* FontExtensions.swift */,
 				6AE264F22975FD270055250A /* StringExtensions.swift */,
 				6A4613182982080E00346D68 /* AlertExtensions.swift */,
+				6A5DA489298C03A700CEA7CD /* DateExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -405,6 +411,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A5DA48C298C113400CEA7CD /* .swiftformat in Resources */,
 				6AF033EE2954CF3F0043FB6A /* Localizable.strings in Resources */,
 				6AC5CFB32953FA750046325C /* .swiftformat in Resources */,
 				6A40154F29526796003A6659 /* Preview Assets.xcassets in Resources */,
@@ -466,6 +473,7 @@
 				6AA6596B297B2DB000E980AD /* Account.swift in Sources */,
 				6A461309298191F700346D68 /* DisplayName.swift in Sources */,
 				6A4613192982080E00346D68 /* AlertExtensions.swift in Sources */,
+				6A5DA48A298C03A700CEA7CD /* DateExtensions.swift in Sources */,
 				6A46131B2982118500346D68 /* ErrorViewModel.swift in Sources */,
 				6A40157F2952B237003A6659 /* FontExtensions.swift in Sources */,
 				6A4613052981836F00346D68 /* MessageListView.swift in Sources */,
@@ -643,7 +651,7 @@
 				CURRENT_PROJECT_VERSION = 3;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"xmtp-inbox-ios/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = FY4NZR34Z3;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -33,7 +33,6 @@
 		6A46131B2982118500346D68 /* ErrorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A46131A2982118500346D68 /* ErrorViewModel.swift */; };
 		6A46132929831BD800346D68 /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A46132829831BD800346D68 /* AccountView.swift */; };
 		6A5DA48A298C03A700CEA7CD /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5DA489298C03A700CEA7CD /* DateExtensions.swift */; };
-		6A5DA48C298C113400CEA7CD /* .swiftformat in Resources */ = {isa = PBXBuildFile; fileRef = 6A5DA48B298C113400CEA7CD /* .swiftformat */; };
 		6AA65965297B2A2200E980AD /* WalletConnectSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6AA65964297B2A2200E980AD /* WalletConnectSwift */; };
 		6AA65968297B2A7100E980AD /* WalletConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA65967297B2A7100E980AD /* WalletConnection.swift */; };
 		6AA6596B297B2DB000E980AD /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA6596A297B2DB000E980AD /* Account.swift */; };
@@ -98,7 +97,6 @@
 		6A46131A2982118500346D68 /* ErrorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewModel.swift; sourceTree = "<group>"; };
 		6A46132829831BD800346D68 /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
 		6A5DA489298C03A700CEA7CD /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
-		6A5DA48B298C113400CEA7CD /* .swiftformat */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftformat; sourceTree = "<group>"; };
 		6AA65967297B2A7100E980AD /* WalletConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletConnection.swift; sourceTree = "<group>"; };
 		6AA65969297B2C4000E980AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6AA6596A297B2DB000E980AD /* Account.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Account.swift; sourceTree = "<group>"; };
@@ -153,7 +151,6 @@
 		6A40153A29526795003A6659 = {
 			isa = PBXGroup;
 			children = (
-				6A5DA48B298C113400CEA7CD /* .swiftformat */,
 				A663399E2989CF1600477E2E /* Secrets.xcconfig */,
 				A682B1E8298B071800121651 /* ci_scripts */,
 				6AE264E52973D3CD0055250A /* README.md */,
@@ -411,7 +408,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6A5DA48C298C113400CEA7CD /* .swiftformat in Resources */,
 				6AF033EE2954CF3F0043FB6A /* Localizable.strings in Resources */,
 				6AC5CFB32953FA750046325C /* .swiftformat in Resources */,
 				6A40154F29526796003A6659 /* Preview Assets.xcassets in Resources */,

--- a/xmtp-inbox-ios/Extensions/DateExtensions.swift
+++ b/xmtp-inbox-ios/Extensions/DateExtensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Date {
-	func timeAgo() -> String {
+	var timeAgo: String {
 		let formatter = RelativeDateTimeFormatter()
 		formatter.unitsStyle = .short
 		return formatter.localizedString(for: self, relativeTo: Date())

--- a/xmtp-inbox-ios/Extensions/DateExtensions.swift
+++ b/xmtp-inbox-ios/Extensions/DateExtensions.swift
@@ -1,0 +1,16 @@
+//
+//  DateExtensions.swift
+//  xmtp-inbox-ios
+//
+//  Created by Elise Alix on 2/2/23.
+//
+
+import Foundation
+
+extension Date {
+	func timeAgo() -> String {
+		let formatter = RelativeDateTimeFormatter()
+		formatter.unitsStyle = .short
+		return formatter.localizedString(for: self, relativeTo: Date())
+	}
+}

--- a/xmtp-inbox-ios/Extensions/FontExtensions.swift
+++ b/xmtp-inbox-ios/Extensions/FontExtensions.swift
@@ -13,6 +13,7 @@ extension Font {
 	static let H1 = Font.system(size: 18, weight: .bold)
 	static let Body1 = Font.system(size: 16)
 	static let Body2 = Font.system(size: 15)
+	static let BodyXS = Font.system(size: 13)
 	static let Body1B = Font.system(size: 16, weight: .bold)
 	static let Title2H = Font.system(size: 15, weight: .bold)
 }

--- a/xmtp-inbox-ios/Views/ConversationCellView.swift
+++ b/xmtp-inbox-ios/Views/ConversationCellView.swift
@@ -27,7 +27,7 @@ struct ConversationCellView: View {
 						.font(.Body1B)
 					if mostRecentMessage != nil {
 						// swiftlint:disable force_unwrapping
-						Text(mostRecentMessage!.sent.timeAgo())
+						Text(mostRecentMessage!.sent.timeAgo)
 							.frame(maxWidth: .infinity, alignment: .trailing)
 							.lineLimit(1)
 							.font(.BodyXS)
@@ -60,7 +60,7 @@ struct ConversationCellView: View {
 			guard let mostRecentMessage else {
 				return ""
 			}
-			return try message.content()
+			return try mostRecentMessage.content()
 		} catch {
 			print("Error reading message content")
 			return ""

--- a/xmtp-inbox-ios/Views/ConversationCellView.swift
+++ b/xmtp-inbox-ios/Views/ConversationCellView.swift
@@ -9,13 +9,9 @@ import SwiftUI
 import XMTP
 
 struct ConversationCellView: View {
-	enum EnsError: Error {
-		case invalidURL
-	}
-
 	var conversation: XMTP.Conversation
 
-	var messagePreview: String
+	var mostRecentMessage: DecodedMessage?
 
 	var displayName: DisplayName
 
@@ -23,11 +19,24 @@ struct ConversationCellView: View {
 		HStack(alignment: .top) {
 			EnsImageView(imageSize: 48.0, peerAddress: conversation.peerAddress)
 			VStack(alignment: .leading) {
-				Text(displayName.resolvedName)
-					.padding(.horizontal, 4.0)
-					.padding(.bottom, 1.0)
-					.lineLimit(1)
-					.font(.Body1B)
+				HStack {
+					Text(displayName.resolvedName)
+						.padding(.horizontal, 4.0)
+						.padding(.bottom, 1.0)
+						.lineLimit(1)
+						.font(.Body1B)
+					if mostRecentMessage != nil {
+						// swiftlint:disable force_unwrapping
+						Text(mostRecentMessage!.sent.timeAgo())
+							.frame(maxWidth: .infinity, alignment: .trailing)
+							.lineLimit(1)
+							.font(.BodyXS)
+							.foregroundColor(.textScondary)
+							.padding(.horizontal, 4.0)
+							.padding(.bottom, 1.0)
+						// swiftlint:enable force_unwrapping
+					}
+				}
 				if messagePreview.isEmpty {
 					Text("no-message-preview")
 						.padding(.horizontal, 4.0)
@@ -43,6 +52,18 @@ struct ConversationCellView: View {
 						.foregroundColor(.textScondary)
 				}
 			}
+		}
+	}
+
+	var messagePreview: String {
+		do {
+			guard let message = mostRecentMessage else {
+				return ""
+			}
+			return try message.content()
+		} catch {
+			print("Error reading message content")
+			return ""
 		}
 	}
 }

--- a/xmtp-inbox-ios/Views/ConversationCellView.swift
+++ b/xmtp-inbox-ios/Views/ConversationCellView.swift
@@ -57,7 +57,7 @@ struct ConversationCellView: View {
 
 	var messagePreview: String {
 		do {
-			guard let message = mostRecentMessage else {
+			guard let mostRecentMessage else {
 				return ""
 			}
 			return try message.content()

--- a/xmtp-inbox-ios/Views/ConversationListView.swift
+++ b/xmtp-inbox-ios/Views/ConversationListView.swift
@@ -19,7 +19,7 @@ struct ConversationListView: View {
 
 	@State private var ethClient: EthereumHttpClient?
 
-	@State private var messagePreviews = [String: String]()
+	@State private var mostRecentMessages = [String: DecodedMessage]()
 
 	@State private var displayNames = [String: DisplayName]()
 
@@ -47,7 +47,7 @@ struct ConversationListView: View {
 						) {
 							ConversationCellView(
 								conversation: conversation,
-								messagePreview: messagePreviews[conversation.peerAddress] ?? "",
+								mostRecentMessage: mostRecentMessages[conversation.peerAddress],
 								displayName: displayName(conversation)
 							)
 						}
@@ -111,7 +111,7 @@ struct ConversationListView: View {
 			var newMessages = [String: DecodedMessage]()
 			for conversation in newConversations {
 				let message = await loadMostRecentMessage(conversation: conversation)
-				messagePreviews[conversation.peerAddress] = try message?.content() ?? ""
+				mostRecentMessages[conversation.peerAddress] = message
 				newMessages[conversation.peerAddress] = message
 			}
 
@@ -146,10 +146,10 @@ struct ConversationListView: View {
 				where newConversation.peerAddress != client.address
 			{
 				let message = await loadMostRecentMessage(conversation: newConversation)
-				let content = try message?.content() ?? ""
-				messagePreviews[newConversation.peerAddress] = content
+				mostRecentMessages[newConversation.peerAddress] = message
 				loadEnsNames(addresses: [EthereumAddress(newConversation.peerAddress)])
 
+				let content = try message?.content() ?? ""
 				await MainActor.run {
 					withAnimation {
 						if content.isEmpty {

--- a/xmtp-inbox-iosTests/xmtp_inbox_iosTests.swift
+++ b/xmtp-inbox-iosTests/xmtp_inbox_iosTests.swift
@@ -8,26 +8,26 @@
 import XCTest
 
 final class xmtp_inbox_iosTests: XCTestCase {
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+	override func setUpWithError() throws {
+		// Put setup code here. This method is called before the invocation of each test method in the class.
+	}
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
+	override func tearDownWithError() throws {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+	}
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
+	func testExample() throws {
+		// This is an example of a functional test case.
+		// Use XCTAssert and related functions to verify your tests produce the correct results.
+		// Any test you write for XCTest can be annotated as throws and async.
+		// Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+		// Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+	}
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+	func testPerformanceExample() throws {
+		// This is an example of a performance test case.
+		measure {
+			// Put the code you want to measure the time of here.
+		}
+	}
 }

--- a/xmtp-inbox-iosUITests/xmtp_inbox_iosUITestsLaunchTests.swift
+++ b/xmtp-inbox-iosUITests/xmtp_inbox_iosUITestsLaunchTests.swift
@@ -8,24 +8,24 @@
 import XCTest
 
 final class xmtp_inbox_iosUITestsLaunchTests: XCTestCase {
-    override class var runsForEachTargetApplicationUIConfiguration: Bool {
-        true
-    }
+	override class var runsForEachTargetApplicationUIConfiguration: Bool {
+		true
+	}
 
-    override func setUpWithError() throws {
-        continueAfterFailure = false
-    }
+	override func setUpWithError() throws {
+		continueAfterFailure = false
+	}
 
-    func testLaunch() throws {
-        let app = XCUIApplication()
-        app.launch()
+	func testLaunch() throws {
+		let app = XCUIApplication()
+		app.launch()
 
-        // Insert steps here to perform after app launch but before taking a screenshot,
-        // such as logging into a test account or navigating somewhere in the app
+		// Insert steps here to perform after app launch but before taking a screenshot,
+		// such as logging into a test account or navigating somewhere in the app
 
-        let attachment = XCTAttachment(screenshot: app.screenshot())
-        attachment.name = "Launch Screen"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-    }
+		let attachment = XCTAttachment(screenshot: app.screenshot())
+		attachment.name = "Launch Screen"
+		attachment.lifetime = .keepAlways
+		add(attachment)
+	}
 }


### PR DESCRIPTION
This PR adds a relative timestamp to each conversation in the list. I had to pass in the actual message instead of just the preview string to the list cell, but I figure we might want more info from it in the future anyways. This should be the last missing feature of a v1 conversation list!

Resolves #18 

| Light | Dark |
|--|--|
| ![IMG_0006](https://user-images.githubusercontent.com/556051/216371643-29989219-4200-4e4f-bd9d-e14c4ea7e281.PNG) | ![Screenshot 2023-02-02 at 10 38 08 AM](https://user-images.githubusercontent.com/556051/216371676-5abf8364-54fb-47ec-af3b-b7bbf023deef.png) |