### PR TITLE
Don't limit WC QR code to debug

### DIFF
--- a/xmtp-inbox-ios/ContentView.swift
+++ b/xmtp-inbox-ios/ContentView.swift
@@ -89,9 +89,7 @@ struct ContentView: View {
 				await MainActor.run {
 					self.wcUrl = url
 
-					#if DEBUG
-						auth.isShowingQRCode = !UIApplication.shared.canOpenURL(url)
-					#endif
+					auth.isShowingQRCode = !UIApplication.shared.canOpenURL(url)
 				}
 				await UIApplication.shared.open(url)
 


### PR DESCRIPTION
This will allow logging in on devices like iPads that may not have a wallet installed.