### PR TITLE
Persistence Follow Ups

### DIFF
--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		6AF033F02954F62A0043FB6A /* ConversationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF033EF2954F62A0043FB6A /* ConversationListView.swift */; };
 		6AF033F22954F8560043FB6A /* PreviewClientProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF033F12954F8560043FB6A /* PreviewClientProvider.swift */; };
 		6AF033F4295504B70043FB6A /* Print.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AF033F3295504B70043FB6A /* Print.swift */; };
+		A6292C31299415E4004B5A27 /* SQLDebuggerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6292C30299415E4004B5A27 /* SQLDebuggerView.swift */; };
 		A66339A02989D14400477E2E /* QRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A663399F2989D14400477E2E /* QRCode.swift */; };
 		A66339A22989D1FE00477E2E /* QRCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66339A12989D1FE00477E2E /* QRCodeView.swift */; };
 		A671F71A2992C01900C0F36D /* KeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A671F7192992C01900C0F36D /* KeyStoreTests.swift */; };
@@ -59,6 +60,7 @@
 		A68C8A4C298C6818003A9A95 /* XMTP in Frameworks */ = {isa = PBXBuildFile; productRef = A68C8A4B298C6818003A9A95 /* XMTP */; };
 		A68C8A4F298C6CC1003A9A95 /* ConversationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A4E298C6CC1003A9A95 /* ConversationLoader.swift */; };
 		A68C8A53298C8BED003A9A95 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A52298C8BED003A9A95 /* Message.swift */; };
+		A6A5AB7A29941DC6004F5006 /* ConversationLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A5AB7929941DC6004F5006 /* ConversationLoaderTests.swift */; };
 		C0FC8F7534D053D77C7844DE /* Pods_xmtp_inbox_ios_xmtp_inbox_iosUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 317FFBF07954FD4F1A3422AD /* Pods_xmtp_inbox_ios_xmtp_inbox_iosUITests.framework */; };
 		CF1B45F2A383A42721D7B5B6 /* Pods_xmtp_inbox_iosTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BAB8C6461BBE02BE6BF8821 /* Pods_xmtp_inbox_iosTests.framework */; };
 		F1BB0538CF0E2195050C8888 /* Pods_xmtp_inbox_ios.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D16EA21E60F9FF562F6B944D /* Pods_xmtp_inbox_ios.framework */; };
@@ -128,6 +130,7 @@
 		6AF033F3295504B70043FB6A /* Print.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Print.swift; sourceTree = "<group>"; };
 		7E2FCF1D984B2A694A607529 /* Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.release.xcconfig"; path = "Target Support Files/Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests/Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.release.xcconfig"; sourceTree = "<group>"; };
 		9B491ED89471263D2CAFB3CB /* Pods-xmtp-inbox-ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtp-inbox-ios.release.xcconfig"; path = "Target Support Files/Pods-xmtp-inbox-ios/Pods-xmtp-inbox-ios.release.xcconfig"; sourceTree = "<group>"; };
+		A6292C30299415E4004B5A27 /* SQLDebuggerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLDebuggerView.swift; sourceTree = "<group>"; };
 		A65544A5298C5AA8005337C3 /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A663399E2989CF1600477E2E /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		A663399F2989D14400477E2E /* QRCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCode.swift; sourceTree = "<group>"; };
@@ -142,6 +145,7 @@
 		A68C8A49298C64FC003A9A95 /* DBConversationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DBConversationTests.swift; sourceTree = "<group>"; };
 		A68C8A4E298C6CC1003A9A95 /* ConversationLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLoader.swift; sourceTree = "<group>"; };
 		A68C8A52298C8BED003A9A95 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		A6A5AB7929941DC6004F5006 /* ConversationLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationLoaderTests.swift; sourceTree = "<group>"; };
 		C99AE74FEC77F3029E8F36C6 /* Pods-xmtp-inbox-iosTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtp-inbox-iosTests.debug.xcconfig"; path = "Target Support Files/Pods-xmtp-inbox-iosTests/Pods-xmtp-inbox-iosTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D16EA21E60F9FF562F6B944D /* Pods_xmtp_inbox_ios.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_xmtp_inbox_ios.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2668044F5BCBB4A1437CAED /* Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.debug.xcconfig"; path = "Target Support Files/Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests/Pods-xmtp-inbox-ios-xmtp-inbox-iosUITests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -252,6 +256,7 @@
 		6A40155729526796003A6659 /* xmtp-inbox-iosTests */ = {
 			isa = PBXGroup;
 			children = (
+				A6A5AB7829941DB8004F5006 /* Loaders */,
 				6A40155829526796003A6659 /* xmtp_inbox_iosTests.swift */,
 				A68C8A49298C64FC003A9A95 /* DBConversationTests.swift */,
 				A671F7192992C01900C0F36D /* KeyStoreTests.swift */,
@@ -283,6 +288,7 @@
 				6A46132829831BD800346D68 /* AccountView.swift */,
 				A66339A12989D1FE00477E2E /* QRCodeView.swift */,
 				6ACD972E298AE3F000C6AD66 /* HapticButton.swift */,
+				A6292C30299415E4004B5A27 /* SQLDebuggerView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -354,6 +360,14 @@
 			children = (
 				A68C8A4E298C6CC1003A9A95 /* ConversationLoader.swift */,
 				A677CEA5298CB97100055697 /* MessageLoader.swift */,
+			);
+			path = Loaders;
+			sourceTree = "<group>";
+		};
+		A6A5AB7829941DB8004F5006 /* Loaders */ = {
+			isa = PBXGroup;
+			children = (
+				A6A5AB7929941DC6004F5006 /* ConversationLoaderTests.swift */,
 			);
 			path = Loaders;
 			sourceTree = "<group>";
@@ -658,6 +672,7 @@
 				6AF033F22954F8560043FB6A /* PreviewClientProvider.swift in Sources */,
 				6A46132929831BD800346D68 /* AccountView.swift in Sources */,
 				6AF033F02954F62A0043FB6A /* ConversationListView.swift in Sources */,
+				A6292C31299415E4004B5A27 /* SQLDebuggerView.swift in Sources */,
 				6AA6596B297B2DB000E980AD /* Account.swift in Sources */,
 				6A461309298191F700346D68 /* DisplayName.swift in Sources */,
 				6A4613192982080E00346D68 /* AlertExtensions.swift in Sources */,
@@ -695,6 +710,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6A40155929526796003A6659 /* xmtp_inbox_iosTests.swift in Sources */,
+				A6A5AB7A29941DC6004F5006 /* ConversationLoaderTests.swift in Sources */,
 				A671F71A2992C01900C0F36D /* KeyStoreTests.swift in Sources */,
 				A68C8A4A298C64FC003A9A95 /* DBConversationTests.swift in Sources */,
 			);

--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		6A40154F29526796003A6659 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 6A40154E29526796003A6659 /* Preview Assets.xcassets */; };
 		6A40155929526796003A6659 /* xmtp_inbox_iosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40155829526796003A6659 /* xmtp_inbox_iosTests.swift */; };
 		6A40156329526796003A6659 /* xmtp_inbox_iosUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40156229526796003A6659 /* xmtp_inbox_iosUITests.swift */; };
-		6A401573295267D7003A6659 /* XMTP in Frameworks */ = {isa = PBXBuildFile; productRef = 6A401572295267D7003A6659 /* XMTP */; };
 		6A40157A29529F85003A6659 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40157929529F85003A6659 /* HomeView.swift */; };
 		6A40157D2952AEFB003A6659 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40157C2952AEFB003A6659 /* ColorExtensions.swift */; };
 		6A40157F2952B237003A6659 /* FontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A40157E2952B237003A6659 /* FontExtensions.swift */; };
@@ -57,9 +56,10 @@
 		A68C8A46298C61C6003A9A95 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A45298C61C6003A9A95 /* Model.swift */; };
 		A68C8A48298C61E9003A9A95 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A47298C61E9003A9A95 /* Conversation.swift */; };
 		A68C8A4A298C64FC003A9A95 /* DBConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A49298C64FC003A9A95 /* DBConversationTests.swift */; };
-		A68C8A4C298C6818003A9A95 /* XMTP in Frameworks */ = {isa = PBXBuildFile; productRef = A68C8A4B298C6818003A9A95 /* XMTP */; };
 		A68C8A4F298C6CC1003A9A95 /* ConversationLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A4E298C6CC1003A9A95 /* ConversationLoader.swift */; };
 		A68C8A53298C8BED003A9A95 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A52298C8BED003A9A95 /* Message.swift */; };
+		A69C92752994286C00E49F9B /* XMTP in Frameworks */ = {isa = PBXBuildFile; productRef = A69C92742994286C00E49F9B /* XMTP */; };
+		A69C928129942DD300E49F9B /* XMTPTestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = A69C928029942DD300E49F9B /* XMTPTestHelpers */; };
 		A6A5AB7A29941DC6004F5006 /* ConversationLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6A5AB7929941DC6004F5006 /* ConversationLoaderTests.swift */; };
 		C0FC8F7534D053D77C7844DE /* Pods_xmtp_inbox_ios_xmtp_inbox_iosUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 317FFBF07954FD4F1A3422AD /* Pods_xmtp_inbox_ios_xmtp_inbox_iosUITests.framework */; };
 		CF1B45F2A383A42721D7B5B6 /* Pods_xmtp_inbox_iosTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5BAB8C6461BBE02BE6BF8821 /* Pods_xmtp_inbox_iosTests.framework */; };
@@ -157,11 +157,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				6AE264EB2974F62B0055250A /* IGIdenticon in Frameworks */,
+				A69C92752994286C00E49F9B /* XMTP in Frameworks */,
 				6AE264E82974E63F0055250A /* ENSKit in Frameworks */,
 				6AA65965297B2A2200E980AD /* WalletConnectSwift in Frameworks */,
 				6A4613112981F96300346D68 /* AlertToast in Frameworks */,
 				6A1C37DE2971A3C900AF6559 /* web3.swift in Frameworks */,
-				6A401573295267D7003A6659 /* XMTP in Frameworks */,
 				F1BB0538CF0E2195050C8888 /* Pods_xmtp_inbox_ios.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -171,7 +171,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CF1B45F2A383A42721D7B5B6 /* Pods_xmtp_inbox_iosTests.framework in Frameworks */,
-				A68C8A4C298C6818003A9A95 /* XMTP in Frameworks */,
+				A69C928129942DD300E49F9B /* XMTPTestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -405,12 +405,12 @@
 			);
 			name = "xmtp-inbox-ios";
 			packageProductDependencies = (
-				6A401572295267D7003A6659 /* XMTP */,
 				6A1C37DD2971A3C900AF6559 /* web3.swift */,
 				6AE264E72974E63F0055250A /* ENSKit */,
 				6AE264EA2974F62B0055250A /* IGIdenticon */,
 				6AA65964297B2A2200E980AD /* WalletConnectSwift */,
 				6A4613102981F96300346D68 /* AlertToast */,
+				A69C92742994286C00E49F9B /* XMTP */,
 			);
 			productName = "xmtp-inbox-ios";
 			productReference = 6A40154329526795003A6659 /* xmtp-inbox-ios.app */;
@@ -432,7 +432,7 @@
 			);
 			name = "xmtp-inbox-iosTests";
 			packageProductDependencies = (
-				A68C8A4B298C6818003A9A95 /* XMTP */,
+				A69C928029942DD300E49F9B /* XMTPTestHelpers */,
 			);
 			productName = "xmtp-inbox-iosTests";
 			productReference = 6A40155429526796003A6659 /* xmtp-inbox-iosTests.xctest */;
@@ -454,6 +454,8 @@
 				6A40156029526796003A6659 /* PBXTargetDependency */,
 			);
 			name = "xmtp-inbox-iosUITests";
+			packageProductDependencies = (
+			);
 			productName = "xmtp-inbox-iosUITests";
 			productReference = 6A40155E29526796003A6659 /* xmtp-inbox-iosUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -491,12 +493,12 @@
 			);
 			mainGroup = 6A40153A29526795003A6659;
 			packageReferences = (
-				6A401571295267D7003A6659 /* XCRemoteSwiftPackageReference "xmtp-ios" */,
 				6A1C37DC2971A3C900AF6559 /* XCRemoteSwiftPackageReference "web3" */,
 				6AE264E62974E63F0055250A /* XCRemoteSwiftPackageReference "ENSKit" */,
 				6AE264E92974F62B0055250A /* XCRemoteSwiftPackageReference "IGIdenticon" */,
 				6AA65963297B2A2200E980AD /* XCRemoteSwiftPackageReference "WalletConnectSwift" */,
 				6A46130F2981F96300346D68 /* XCRemoteSwiftPackageReference "AlertToast" */,
+				A69C92732994286C00E49F9B /* XCRemoteSwiftPackageReference "xmtp-ios" */,
 			);
 			productRefGroup = 6A40154429526795003A6659 /* Products */;
 			projectDirPath = "";
@@ -1090,14 +1092,6 @@
 				version = 1.4.1;
 			};
 		};
-		6A401571295267D7003A6659 /* XCRemoteSwiftPackageReference "xmtp-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/xmtp/xmtp-ios";
-			requirement = {
-				branch = "public-convos";
-				kind = branch;
-			};
-		};
 		6A46130F2981F96300346D68 /* XCRemoteSwiftPackageReference "AlertToast" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/elai950/AlertToast.git";
@@ -1130,6 +1124,14 @@
 				version = 0.8.0;
 			};
 		};
+		A69C92732994286C00E49F9B /* XCRemoteSwiftPackageReference "xmtp-ios" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/xmtp/xmtp-ios";
+			requirement = {
+				branch = "test-helpers";
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1137,11 +1139,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 6A1C37DC2971A3C900AF6559 /* XCRemoteSwiftPackageReference "web3" */;
 			productName = web3.swift;
-		};
-		6A401572295267D7003A6659 /* XMTP */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 6A401571295267D7003A6659 /* XCRemoteSwiftPackageReference "xmtp-ios" */;
-			productName = XMTP;
 		};
 		6A4613102981F96300346D68 /* AlertToast */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1163,10 +1160,15 @@
 			package = 6AE264E92974F62B0055250A /* XCRemoteSwiftPackageReference "IGIdenticon" */;
 			productName = IGIdenticon;
 		};
-		A68C8A4B298C6818003A9A95 /* XMTP */ = {
+		A69C92742994286C00E49F9B /* XMTP */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6A401571295267D7003A6659 /* XCRemoteSwiftPackageReference "xmtp-ios" */;
+			package = A69C92732994286C00E49F9B /* XCRemoteSwiftPackageReference "xmtp-ios" */;
 			productName = XMTP;
+		};
+		A69C928029942DD300E49F9B /* XMTPTestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A69C92732994286C00E49F9B /* XCRemoteSwiftPackageReference "xmtp-ios" */;
+			productName = XMTPTestHelpers;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/xmtp-inbox-ios.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xmtp-inbox-ios.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift",
       "state" : {
-        "revision" : "1629de188c25682adc4cb47a80adca1ac90b494d",
-        "version" : "1.13.2"
+        "revision" : "783ed8ddcde07ac0332a5ec4647b665f82e95b78",
+        "version" : "1.14.0"
       }
     },
     {
@@ -87,7 +87,7 @@
       "location" : "https://github.com/xmtp/proto",
       "state" : {
         "branch" : "main",
-        "revision" : "07180005024b320da26ee35f0b47ae9a459043f0"
+        "revision" : "2492c07969696a9d16930ed20cd702641cc7cad0"
       }
     },
     {
@@ -96,7 +96,7 @@
       "location" : "https://github.com/GigaBitcoin/secp256k1.swift.git",
       "state" : {
         "branch" : "main",
-        "revision" : "5a162be81f45d6972c0b30022a4ca3dbd49541ff"
+        "revision" : "ff0cf699a48df87213c89396c9bd6a6d776db9a5"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "b408ca74bf24d13310da685bc340f149567c4ae2",
-        "version" : "1.24.0"
+        "revision" : "22757ac305f3d44d2b99ba541193ff1d64e77d00",
+        "version" : "1.24.1"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/xmtp/xmtp-ios",
       "state" : {
-        "branch" : "public-convos",
-        "revision" : "5d4289555e149c7ad7103fbb46b459ee0fb5dbeb"
+        "branch" : "test-helpers",
+        "revision" : "015966789c79ca181bc1c8c2925d92f778898ca0"
       }
     }
   ],

--- a/xmtp-inbox-ios.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/xmtp-inbox-ios.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift",
       "state" : {
-        "revision" : "783ed8ddcde07ac0332a5ec4647b665f82e95b78",
-        "version" : "1.14.0"
+        "revision" : "1629de188c25682adc4cb47a80adca1ac90b494d",
+        "version" : "1.13.2"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "22757ac305f3d44d2b99ba541193ff1d64e77d00",
-        "version" : "1.24.1"
+        "revision" : "b408ca74bf24d13310da685bc340f149567c4ae2",
+        "version" : "1.24.0"
       }
     },
     {

--- a/xmtp-inbox-ios/Loaders/ConversationLoader.swift
+++ b/xmtp-inbox-ios/Loaders/ConversationLoader.swift
@@ -42,8 +42,10 @@ class ConversationLoader: ObservableObject {
 			try DB.Conversation
 				.including(optional: DB.Conversation.lastMessage.forKey("lastMessage"))
 				.asRequest(of: ConversationWithLastMessage.self)
+				.group(Column("id"))
 				.fetchAll(db)
 		}.map { result in
+			print("RESULT \(result.conversation.id ?? -1)")
 			var conversation = result.conversation
 			conversation.lastMessage = result.lastMessage
 			return conversation

--- a/xmtp-inbox-ios/Loaders/ConversationLoader.swift
+++ b/xmtp-inbox-ios/Loaders/ConversationLoader.swift
@@ -58,6 +58,7 @@ class ConversationLoader: ObservableObject {
 
 	func fetchRemote() async throws {
 		for conversation in try await client.conversations.list() {
+			print("FOUND A CONVO \(conversation)")
 			try await DB.Conversation.from(conversation)
 		}
 
@@ -66,14 +67,19 @@ class ConversationLoader: ObservableObject {
 
 		let conversations = await conversations
 		let addresses = conversations.map(\.peerAddress)
-		let ensResults = try await ENS.shared.ens(addresses: addresses)
-		for (i, conversation) in conversations.enumerated() {
-			var conversation = conversation
-			conversation.ens = ensResults[i]
-			try conversation.save()
+		do {
+			let ensResults = try await ENS.shared.ens(addresses: addresses)
+			
+			for (i, conversation) in conversations.enumerated() {
+				var conversation = conversation
+				conversation.ens = ensResults[i]
+				try conversation.save()
+			}
+		} catch {
+			print("Error loading ENS: \(error)")
 		}
 
-		// Reload view now that we have ENS names
+//		// Reload view now that we have ENS names
 		try await fetchLocal()
 	}
 

--- a/xmtp-inbox-ios/Loaders/ConversationLoader.swift
+++ b/xmtp-inbox-ios/Loaders/ConversationLoader.swift
@@ -78,7 +78,7 @@ class ConversationLoader: ObservableObject {
 			print("Error loading ENS: \(error)")
 		}
 
-//		// Reload view now that we have ENS names
+		// Reload view now that we have ENS names
 		try await fetchLocal()
 	}
 

--- a/xmtp-inbox-ios/Loaders/ConversationLoader.swift
+++ b/xmtp-inbox-ios/Loaders/ConversationLoader.swift
@@ -58,7 +58,6 @@ class ConversationLoader: ObservableObject {
 
 	func fetchRemote() async throws {
 		for conversation in try await client.conversations.list() {
-			print("FOUND A CONVO \(conversation)")
 			try await DB.Conversation.from(conversation)
 		}
 

--- a/xmtp-inbox-ios/Loaders/MessageLoader.swift
+++ b/xmtp-inbox-ios/Loaders/MessageLoader.swift
@@ -28,7 +28,7 @@ class MessageLoader: ObservableObject {
 		let messages = try await DB.shared.queue.read { db in
 			try DB.Message
 				.filter(Column("conversationID") == self.conversation.id)
-				.order(Column("createdAt").desc)
+				.order(Column("createdAt").asc)
 				.fetchAll(db)
 		}
 

--- a/xmtp-inbox-ios/Loaders/MessageLoader.swift
+++ b/xmtp-inbox-ios/Loaders/MessageLoader.swift
@@ -22,6 +22,18 @@ class MessageLoader: ObservableObject {
 
 	func load() async throws {
 		try await fetchLocal()
+		try await fetchRemote()
+	}
+
+	// TODO: paginate
+	func fetchRemote() async throws {
+		let messages = try await conversation.toXMTP(client: client).messages()
+
+		for message in messages {
+			_ = try DB.Message.from(message, conversation: conversation)
+		}
+
+		try await fetchLocal()
 	}
 
 	func fetchLocal() async throws {

--- a/xmtp-inbox-ios/Models/Conversation.swift
+++ b/xmtp-inbox-ios/Models/Conversation.swift
@@ -128,5 +128,5 @@ extension DB.Conversation: Model {
 	}
 
 	// Associations
-	static let lastMessage = hasOne(DB.Message.self, key: "id", using: ForeignKey(["conversationID"])).order(Column("createdAt").desc)
+	static let lastMessage = hasOne(DB.Message.self, key: "id", using: ForeignKey(["conversationID"])).select(AllColumns(), max(Column("createdAt")))
 }

--- a/xmtp-inbox-ios/Models/DB.swift
+++ b/xmtp-inbox-ios/Models/DB.swift
@@ -56,6 +56,13 @@ class DB {
 		}
 	}
 
+	func clear() throws {
+		try queue.write { db in
+			try DB.Conversation.deleteAll(db)
+			try DB.Message.deleteAll(db)
+		}
+	}
+
 	var location: URL {
 		URL.documentsDirectory.appendingPathComponent("db\(mode == .normal ? "" : "-test").sqlite")
 	}

--- a/xmtp-inbox-ios/Models/DB.swift
+++ b/xmtp-inbox-ios/Models/DB.swift
@@ -9,6 +9,10 @@ import Foundation
 import GRDB
 
 class DB {
+	enum DBError: Error {
+		case badData(String)
+	}
+
 	static let shared = DB()
 
 	enum Mode {

--- a/xmtp-inbox-ios/Models/Message.swift
+++ b/xmtp-inbox-ios/Models/Message.swift
@@ -35,6 +35,10 @@ extension DB {
 				throw Conversation.ConversationError.conversionError("no conversation ID")
 			}
 
+			if xmtpMessage.id == "" {
+				throw DBError.badData("Missing XMTP ID")
+			}
+
 			var message = DB.Message(
 				xmtpID: xmtpMessage.id,
 				body: try xmtpMessage.content(),

--- a/xmtp-inbox-ios/ViewModels/Auth.swift
+++ b/xmtp-inbox-ios/ViewModels/Auth.swift
@@ -20,6 +20,7 @@ class Auth: ObservableObject {
 	func signOut() {
 		do {
 			try Keystore.deleteKeys()
+			try DB.shared.clear()
 			withAnimation {
 				self.status = .signedOut
 			}

--- a/xmtp-inbox-ios/Views/AccountView.swift
+++ b/xmtp-inbox-ios/Views/AccountView.swift
@@ -144,6 +144,12 @@ struct AccountView: View {
 					}
 					.frame(maxWidth: .infinity)
 					.listRowBackground(Color.backgroundPrimary)
+
+					#if DEBUG
+						NavigationLink(destination: SQLDebuggerView()) {
+							Text("SQL Debugger")
+						}
+					#endif
 				}
 				.scrollContentBackground(.hidden)
 				.background(Color.backgroundPrimary)

--- a/xmtp-inbox-ios/Views/SQLDebuggerView.swift
+++ b/xmtp-inbox-ios/Views/SQLDebuggerView.swift
@@ -1,0 +1,51 @@
+//
+//  SQLDebuggerView.swift
+//  xmtp-inbox-ios
+//
+//  Created by Pat on 2/8/23.
+//
+
+import GRDB
+import SwiftUI
+
+struct SQLDebuggerView: View {
+	@State private var sql: String = "select * from conversation"
+	@State private var results: [String] = []
+
+	var body: some View {
+		List {
+			TextEditor(text: $sql)
+				.font(.system(.body, design: .monospaced))
+				.autocapitalization(.none)
+				.autocorrectionDisabled(true)
+				.lineLimit(4, reservesSpace: true)
+			Button("Run") {
+				do {
+					let results = try DB.shared.queue.read { db in
+						try Row.fetchAll(db, sql: sql)
+					}
+
+					self.results = results.map(\.debugDescription)
+				} catch {
+					print("Error running query: \(error)")
+				}
+			}
+			Section {
+				ForEach(results, id: \.self) { result in
+					Text(result)
+						.font(.system(.body, design: .monospaced))
+				}
+			}
+		}
+		.navigationTitle("SQL Debugger")
+		.navigationBarTitleDisplayMode(.inline)
+	}
+}
+
+struct SQLDebuggerView_Previews: PreviewProvider {
+	static var previews: some View {
+		NavigationView {
+			SQLDebuggerView()
+		}
+	}
+}

--- a/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
+++ b/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
@@ -1,0 +1,21 @@
+//
+//  ConversationLoaderTests.swift
+//  xmtp-inbox-iosTests
+//
+//  Created by Pat on 2/8/23.
+//
+
+import Foundation
+import XCTest
+import XMTP
+@testable import xmtp_inbox_ios
+
+final class ConversationLoaderTests: XCTestCase {
+	override func setUp() async throws {
+		try DB.shared.prepare(passphrase: "test", mode: .test, reset: true)
+	}
+	
+	func testGetsConversations() async throws {
+		let client = XMTP.Client.
+	}
+}

--- a/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
+++ b/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
@@ -5,17 +5,29 @@
 //  Created by Pat on 2/8/23.
 //
 
-import Foundation
 import XCTest
 import XMTP
+import XMTPTestHelpers
 @testable import xmtp_inbox_ios
 
 final class ConversationLoaderTests: XCTestCase {
-	override func setUp() async throws {
-		try DB.shared.prepare(passphrase: "test", mode: .test, reset: true)
-	}
-	
 	func testGetsConversations() async throws {
-		let client = XMTP.Client.
+		try DB.shared.prepare(passphrase: "test", mode: .test, reset: true)
+		
+		let fixtures = await fixtures()
+		let loader = ConversationLoader(client: fixtures.aliceClient)
+		
+		var conversations = await loader.conversations
+		XCTAssert(conversations.isEmpty, "had conversations for some reason??")
+		
+		let conversation = try await fixtures.aliceClient.conversations.newConversation(with: fixtures.bobClient.address)
+		let clientConversations = try await fixtures.aliceClient.conversations.list()
+		
+		XCTAssertEqual(1, clientConversations.count)
+		
+		try await loader.load()
+		conversations = await loader.conversations
+		
+		XCTAssertEqual([conversation.topic], conversations.map(\.topic))
 	}
 }

--- a/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
+++ b/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
@@ -8,12 +8,15 @@
 import XCTest
 import XMTP
 import XMTPTestHelpers
+import GRDB
 @testable import xmtp_inbox_ios
 
 final class ConversationLoaderTests: XCTestCase {
-	func testGetsConversations() async throws {
+	override func setUp() async throws {
 		try DB.shared.prepare(passphrase: "test", mode: .test, reset: true)
-		
+	}
+
+	func testGetsConversations() async throws {
 		let fixtures = await fixtures()
 		let loader = ConversationLoader(client: fixtures.aliceClient)
 		
@@ -29,5 +32,37 @@ final class ConversationLoaderTests: XCTestCase {
 		conversations = await loader.conversations
 		
 		XCTAssertEqual([conversation.topic], conversations.map(\.topic))
+	}
+
+	func testGetsMostRecentMessage() async throws {
+		let fixtures = await fixtures()
+		let loader = ConversationLoader(client: fixtures.aliceClient)
+
+		let conversation = try await fixtures.aliceClient.conversations.newConversation(with: fixtures.bobClient.address)
+		try await conversation.send(text: "1")
+
+		try await loader.load()
+		var conversations = await loader.conversations
+
+		XCTAssertEqual("1", conversations[0].lastMessage?.body)
+
+		let thePast = Date().addingTimeInterval(-1000)
+		try await DB.shared.queue.write { db in
+			try db.execute(sql: "UPDATE message SET createdAt = ?", arguments: [thePast])
+		}
+
+		try await conversation.send(text: "2")
+
+		try await loader.load()
+		conversations = await loader.conversations
+
+		let messages = try await DB.shared.queue.read { db in
+			try DB.Message.order(Column("createdAt").desc).fetchAll(db)
+		}
+
+		print("msesagse \(messages)")
+
+		XCTAssertEqual("2", conversations[0].lastMessage?.body)
+
 	}
 }


### PR DESCRIPTION
- Fixes issue where listing conversations might not show the most recent messages or could show duplicates
- Fixes issue where messages weren't loaded on conversation detail view
- Handle ENS connectivity issues
- Clear the DB when logging out
- Adds a SQL repl in DEBUG from the account page
- Adds the beginnings of unit tests by importing XMTPTestHelpers (still requires test-helpers branch until https://github.com/xmtp/xmtp-ios/pull/57 lands)