### PR TITLE
Handle duplicate conversations

### DIFF
--- a/xmtp-inbox-ios.xcodeproj/project.pbxproj
+++ b/xmtp-inbox-ios.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		A671F71A2992C01900C0F36D /* KeyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A671F7192992C01900C0F36D /* KeyStoreTests.swift */; };
 		A677CE9F298CADF000055697 /* ENS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A677CE9E298CADF000055697 /* ENS.swift */; };
 		A677CEA6298CB97100055697 /* MessageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A677CEA5298CB97100055697 /* MessageLoader.swift */; };
+		A68BCAF729959374001159B8 /* ConversationTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68BCAF629959374001159B8 /* ConversationTopic.swift */; };
 		A68C8A44298C5D97003A9A95 /* DB.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A43298C5D97003A9A95 /* DB.swift */; };
 		A68C8A46298C61C6003A9A95 /* Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A45298C61C6003A9A95 /* Model.swift */; };
 		A68C8A48298C61E9003A9A95 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68C8A47298C61E9003A9A95 /* Conversation.swift */; };
@@ -141,6 +142,7 @@
 		A677CE9E298CADF000055697 /* ENS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ENS.swift; sourceTree = "<group>"; };
 		A677CEA5298CB97100055697 /* MessageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageLoader.swift; sourceTree = "<group>"; };
 		A682B1E9298B074700121651 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		A68BCAF629959374001159B8 /* ConversationTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationTopic.swift; sourceTree = "<group>"; };
 		A68C8A43298C5D97003A9A95 /* DB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DB.swift; sourceTree = "<group>"; };
 		A68C8A45298C61C6003A9A95 /* Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model.swift; sourceTree = "<group>"; };
 		A68C8A47298C61E9003A9A95 /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
@@ -354,6 +356,7 @@
 				A68C8A45298C61C6003A9A95 /* Model.swift */,
 				A68C8A47298C61E9003A9A95 /* Conversation.swift */,
 				A68C8A52298C8BED003A9A95 /* Message.swift */,
+				A68BCAF629959374001159B8 /* ConversationTopic.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -697,6 +700,7 @@
 				A677CEA6298CB97100055697 /* MessageLoader.swift in Sources */,
 				6A4613012981826B00346D68 /* MessageComposerView.swift in Sources */,
 				A68C8A4F298C6CC1003A9A95 /* ConversationLoader.swift in Sources */,
+				A68BCAF729959374001159B8 /* ConversationTopic.swift in Sources */,
 				A68C8A46298C61C6003A9A95 /* Model.swift in Sources */,
 				6A46130B2981ABF500346D68 /* ViewExtensions.swift in Sources */,
 				6AE264F32975FD270055250A /* StringExtensions.swift in Sources */,

--- a/xmtp-inbox-ios/Constants.swift
+++ b/xmtp-inbox-ios/Constants.swift
@@ -9,11 +9,11 @@ import Foundation
 import XMTP
 
 struct Constants {
-//	#if DEBUG
-//		static let xmtpEnv: XMTPEnvironment = .dev
-//	#else
+	#if DEBUG
+		static let xmtpEnv: XMTPEnvironment = .dev
+	#else
 		static let xmtpEnv: XMTPEnvironment = .production
-//	#endif
+	#endif
 
 	private static let infuraKey = Bundle.main.infoDictionary?["INFURA_KEY"] as? String ?? ""
 	static let infuraUrl = URL(string: "https://mainnet.infura.io/v3/\(infuraKey)")

--- a/xmtp-inbox-ios/Constants.swift
+++ b/xmtp-inbox-ios/Constants.swift
@@ -9,11 +9,11 @@ import Foundation
 import XMTP
 
 struct Constants {
-	#if DEBUG
-		static let xmtpEnv: XMTPEnvironment = .dev
-	#else
+//	#if DEBUG
+//		static let xmtpEnv: XMTPEnvironment = .dev
+//	#else
 		static let xmtpEnv: XMTPEnvironment = .production
-	#endif
+//	#endif
 
 	private static let infuraKey = Bundle.main.infoDictionary?["INFURA_KEY"] as? String ?? ""
 	static let infuraUrl = URL(string: "https://mainnet.infura.io/v3/\(infuraKey)")

--- a/xmtp-inbox-ios/Loaders/ConversationLoader.swift
+++ b/xmtp-inbox-ios/Loaders/ConversationLoader.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import GRDB
+import SwiftUI
 import XMTP
 
 struct ConversationWithLastMessage: Codable, FetchableRecord {
@@ -56,7 +57,9 @@ class ConversationLoader: ObservableObject {
 		}
 
 		await MainActor.run {
-			self.conversations = conversations
+			withAnimation {
+				self.conversations = conversations
+			}
 		}
 	}
 
@@ -97,7 +100,7 @@ class ConversationLoader: ObservableObject {
 						var conversation = conversation
 						try await conversation.loadMostRecentMessage(client: self.client)
 					} catch {
-						print("Error loading most recent message for \(conversation.topic): \(error)")
+						print("Error loading most recent message for \(conversation.peerAddress): \(error)")
 					}
 				}
 			}

--- a/xmtp-inbox-ios/Loaders/MessageLoader.swift
+++ b/xmtp-inbox-ios/Loaders/MessageLoader.swift
@@ -30,7 +30,11 @@ class MessageLoader: ObservableObject {
 		let messages = try await conversation.toXMTP(client: client).messages()
 
 		for message in messages {
-			_ = try DB.Message.from(message, conversation: conversation)
+			do {
+				_ = try DB.Message.from(message, conversation: conversation)
+			} catch {
+				print("Error importing message: \(error)")
+			}
 		}
 
 		try await fetchLocal()

--- a/xmtp-inbox-ios/Loaders/MessageLoader.swift
+++ b/xmtp-inbox-ios/Loaders/MessageLoader.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import GRDB
+import SwiftUI
 import XMTP
 
 class MessageLoader: ObservableObject {
@@ -27,13 +28,18 @@ class MessageLoader: ObservableObject {
 
 	// TODO: paginate
 	func fetchRemote() async throws {
-		let messages = try await conversation.toXMTP(client: client).messages()
-
-		for message in messages {
+		for topic in conversation.topics() {
 			do {
-				_ = try DB.Message.from(message, conversation: conversation)
+				let messages = try await topic.toXMTP(client: client).messages()
+				for message in messages {
+					do {
+						_ = try DB.Message.from(message, conversation: conversation, topic: topic)
+					} catch {
+						print("Error importing message: \(error)")
+					}
+				}
 			} catch {
-				print("Error importing message: \(error)")
+				print("Error loading messages for convo topic \(topic)")
 			}
 		}
 
@@ -49,7 +55,9 @@ class MessageLoader: ObservableObject {
 		}
 
 		await MainActor.run {
-			self.messages = messages
+			withAnimation {
+				self.messages = messages
+			}
 		}
 	}
 }

--- a/xmtp-inbox-ios/Models/ConversationTopic.swift
+++ b/xmtp-inbox-ios/Models/ConversationTopic.swift
@@ -6,19 +6,62 @@
 //
 
 import GRDB
+import XMTP
 
 extension DB {
 	struct ConversationTopic: Model {
+		enum Version: Codable {
+			case v1, v2
+		}
+
 		static func createTable(db: GRDB.Database) throws {
-			try db.create(table: "conversationTopic") { t in
+			try db.create(table: "conversationTopic", ifNotExists: true) { t in
 				t.autoIncrementedPrimaryKey("id").notNull().unique()
+				t.column("conversationID", .integer).notNull().references("conversation")
 				t.column("topic", .text).notNull().unique()
-				t.column("peerAddress", .text).notNull().unique()
+				t.column("peerAddress", .text).notNull()
+				t.column("version", .blob).notNull()
+				t.column("keyMaterial", .blob)
+				t.column("contextData", .blob)
+				t.column("createdAt", .date)
 			}
 		}
 
 		var id: Int?
+		var conversationID: Int
 		var topic: String
 		var peerAddress: String
+		var createdAt: Date
+		var keyMaterial: Data?
+		var contextData: Data?
+		var version: Version = .v2 // Default to v2
+
+		func toXMTP(client: Client) throws -> XMTP.Conversation {
+			switch version {
+			case .v1:
+				return XMTP.Conversation.v1(
+					XMTP.ConversationV1(
+						client: client,
+						peerAddress: peerAddress,
+						sentAt: createdAt
+					)
+				)
+			case .v2:
+				guard let contextData, let keyMaterial else {
+					throw Conversation.ConversationError.conversionError("missing v2 fields")
+				}
+
+				let context = try InvitationV1.Context(serializedData: contextData)
+				return XMTP.Conversation.v2(
+					XMTP.ConversationV2(
+						topic: topic,
+						keyMaterial: keyMaterial,
+						context: context,
+						peerAddress: peerAddress,
+						client: client
+					)
+				)
+			}
+		}
 	}
 }

--- a/xmtp-inbox-ios/Models/ConversationTopic.swift
+++ b/xmtp-inbox-ios/Models/ConversationTopic.swift
@@ -1,0 +1,24 @@
+//
+//  ConversationTopic.swift
+//  xmtp-inbox-ios
+//
+//  Created by Pat on 2/9/23.
+//
+
+import GRDB
+
+extension DB {
+	struct ConversationTopic: Model {
+		static func createTable(db: GRDB.Database) throws {
+			try db.create(table: "conversationTopic") { t in
+				t.autoIncrementedPrimaryKey("id").notNull().unique()
+				t.column("topic", .text).notNull().unique()
+				t.column("peerAddress", .text).notNull().unique()
+			}
+		}
+
+		var id: Int?
+		var topic: String
+		var peerAddress: String
+	}
+}

--- a/xmtp-inbox-ios/Models/DB.swift
+++ b/xmtp-inbox-ios/Models/DB.swift
@@ -57,12 +57,14 @@ class DB {
 		try queue.write { db in
 			try DB.Conversation.createTable(db: db)
 			try DB.Message.createTable(db: db)
+			try DB.Conversation.createTable(db: db)
 		}
 	}
 
 	func clear() throws {
 		try queue.write { db in
 			try DB.Conversation.deleteAll(db)
+			try DB.ConversationTopic.deleteAll(db)
 			try DB.Message.deleteAll(db)
 		}
 	}

--- a/xmtp-inbox-ios/Models/DB.swift
+++ b/xmtp-inbox-ios/Models/DB.swift
@@ -10,13 +10,17 @@ import GRDB
 
 class DB {
 	// If we need to totally blow away the DB, increment this
-	static let version = 2
+	static let version = 3
 
 	enum DBError: Error {
 		case badData(String)
 	}
 
 	static let shared = DB()
+
+	static func read<T>(perform: (Database) throws -> T) throws -> T {
+		try shared.queue.read(perform)
+	}
 
 	enum Mode {
 		case normal, test
@@ -38,7 +42,11 @@ class DB {
 
 		if reset {
 			// swiftlint:disable no_optional_try
-			try? FileManager.default.removeItem(at: location)
+			do {
+				try FileManager.default.removeItem(at: location)
+			} catch {
+				print("Error removing db at \(location)")
+			}
 			// swiftlint:enable no_optional_try
 		}
 
@@ -46,7 +54,7 @@ class DB {
 			try db.usePassphrase(passphrase)
 
 			#if DEBUG
-				db.trace { print("SQL: \($0)") }
+//				db.trace { print("SQL: \($0)") }
 				self.config.publicStatementArguments = true
 			#endif
 		}
@@ -59,20 +67,20 @@ class DB {
 	func createTables() throws {
 		try queue.write { db in
 			try DB.Conversation.createTable(db: db)
+			try DB.ConversationTopic.createTable(db: db)
 			try DB.Message.createTable(db: db)
-			try DB.Conversation.createTable(db: db)
 		}
 	}
 
 	func clear() throws {
 		try queue.write { db in
-			try DB.Conversation.deleteAll(db)
 			try DB.ConversationTopic.deleteAll(db)
+			try DB.Conversation.deleteAll(db)
 			try DB.Message.deleteAll(db)
 		}
 	}
 
 	var location: URL {
-		URL.documentsDirectory.appendingPathComponent("db\(mode == .normal ? "" : "-test-v\(DB.version)").sqlite")
+		URL.documentsDirectory.appendingPathComponent("db\(mode == .normal ? "" : "-test-v\(DB.version)")-\(Constants.xmtpEnv).sqlite")
 	}
 }

--- a/xmtp-inbox-ios/Models/Message.swift
+++ b/xmtp-inbox-ios/Models/Message.swift
@@ -27,6 +27,8 @@ extension DB {
 		}
 
 		static func from(_ xmtpMessage: XMTP.DecodedMessage, conversation: Conversation) throws -> DB.Message {
+			print("attempting to import xmtpMessage: \(xmtpMessage)")
+
 			if let existing = DB.Message.find(Column("xmtpID") == xmtpMessage.id) {
 				return existing
 			}
@@ -38,6 +40,8 @@ extension DB {
 			if xmtpMessage.id == "" {
 				throw DBError.badData("Missing XMTP ID")
 			}
+
+			print("Got a message: \(try xmtpMessage)")
 
 			var message = DB.Message(
 				xmtpID: xmtpMessage.id,

--- a/xmtp-inbox-ios/Models/Message.swift
+++ b/xmtp-inbox-ios/Models/Message.swift
@@ -14,26 +14,26 @@ extension DB {
 		var xmtpID: String
 		var body: String
 		var conversationID: Int
+		var conversationTopicID: Int
 		var senderAddress: String
 		var createdAt: Date
 
-		init(id: Int? = nil, xmtpID: String, body: String, conversationID: Int, senderAddress: String, createdAt: Date) {
+		init(id: Int? = nil, xmtpID: String, body: String, conversationID: Int, conversationTopicID: Int, senderAddress: String, createdAt: Date) {
 			self.id = id
 			self.xmtpID = xmtpID
 			self.body = body
 			self.conversationID = conversationID
+			self.conversationTopicID = conversationTopicID
 			self.senderAddress = senderAddress
 			self.createdAt = createdAt
 		}
 
-		static func from(_ xmtpMessage: XMTP.DecodedMessage, conversation: Conversation) throws -> DB.Message {
-			print("attempting to import xmtpMessage: \(xmtpMessage)")
-
+		@discardableResult static func from(_ xmtpMessage: XMTP.DecodedMessage, conversation: Conversation, topic: ConversationTopic) throws -> DB.Message {
 			if let existing = DB.Message.find(Column("xmtpID") == xmtpMessage.id) {
 				return existing
 			}
 
-			guard let conversationID = conversation.id else {
+			guard let conversationID = conversation.id, let topicID = topic.id else {
 				throw Conversation.ConversationError.conversionError("no conversation ID")
 			}
 
@@ -41,12 +41,11 @@ extension DB {
 				throw DBError.badData("Missing XMTP ID")
 			}
 
-			print("Got a message: \(try xmtpMessage)")
-
 			var message = DB.Message(
 				xmtpID: xmtpMessage.id,
 				body: try xmtpMessage.content(),
 				conversationID: conversationID,
+				conversationTopicID: topicID,
 				senderAddress: xmtpMessage.senderAddress,
 				createdAt: xmtpMessage.sent
 			)
@@ -65,6 +64,7 @@ extension DB.Message: Model {
 			t.column("xmtpID", .text).notNull().indexed()
 			t.column("body", .text).notNull()
 			t.column("conversationID", .integer).notNull().indexed()
+			t.column("conversationTopicID", .integer).notNull().indexed()
 			t.column("senderAddress", .text).notNull()
 			t.column("createdAt", .date)
 		}
@@ -73,6 +73,6 @@ extension DB.Message: Model {
 
 extension DB.Message {
 	static var preview: DB.Message {
-		DB.Message(xmtpID: "aslkdjfalksdljkafsdjasf", body: "hello there", conversationID: 1, senderAddress: "0x000000000", createdAt: Date())
+		DB.Message(xmtpID: "aslkdjfalksdljkafsdjasf", body: "hello there", conversationID: 1, conversationTopicID: 1, senderAddress: "0x000000000", createdAt: Date())
 	}
 }

--- a/xmtp-inbox-ios/Models/Model.swift
+++ b/xmtp-inbox-ios/Models/Model.swift
@@ -40,19 +40,25 @@ extension Model {
 	}
 
 	static func find(id: Int) -> Self? {
-		// swiftlint:disable no_optional_try
-		try? DB.shared.queue.read { db in
-			try? find(db, key: id)
+		do {
+			return try DB.shared.queue.read { db in
+				try find(db, key: id)
+			}
+		} catch {
+			print("Error finding by ID (\(id)): \(error)")
+			return nil
 		}
-		// swiftlint:enable no_optional_try
 	}
 
 	static func find(_ predicate: SQLSpecificExpressible) -> Self? {
-		// swiftlint:disable no_optional_try
-		try? DB.shared.queue.read { db in
-			try? filter(predicate).fetchOne(db)
+		do {
+			return try DB.shared.queue.read { db in
+				try filter(predicate).fetchOne(db)
+			}
+		} catch {
+			print("Error finding \(predicate) : \(error)")
+			return nil
 		}
-		// swiftlint:enable no_optional_try
 	}
 
 	mutating func save() throws {
@@ -63,11 +69,5 @@ extension Model {
 
 	mutating func didInsert(_ inserted: InsertionSuccess) {
 		id = Int(inserted.rowID)
-	}
-
-	mutating func didUpdate(_ updated: PersistenceSuccess) {
-		if let id = updated.persistenceContainer["id"] as? UInt64 {
-			self.id = Int(id)
-		}
 	}
 }

--- a/xmtp-inbox-ios/Models/Model.swift
+++ b/xmtp-inbox-ios/Models/Model.swift
@@ -62,8 +62,12 @@ extension Model {
 	}
 
 	mutating func save() throws {
-		try DB.shared.queue.write { db in
-			try insert(db, onConflict: .replace)
+		do {
+			try DB.shared.queue.write { db in
+				try insert(db, onConflict: .replace)
+			}
+		} catch {
+			print("Error saving \(self): \(error)")
 		}
 	}
 

--- a/xmtp-inbox-ios/Utilities/ENS.swift
+++ b/xmtp-inbox-ios/Utilities/ENS.swift
@@ -36,8 +36,6 @@ class ENS: ObservableObject {
 			}
 		}
 
-		print("addresses with ENS: \(addressesWithENS)")
-
 		return addressesWithENS
 	}
 

--- a/xmtp-inbox-ios/Utilities/ENS.swift
+++ b/xmtp-inbox-ios/Utilities/ENS.swift
@@ -22,20 +22,23 @@ class ENS: ObservableObject {
 		}
 	}
 
-	func ens(addresses: [String]) async throws -> [String?] {
+	func ens(addresses: [String]) async throws -> [String: String?] {
+		var addressesWithENS = [String: String?]()
+
 		guard let service else {
-			return addresses.map { _ in nil }
+			return addressesWithENS
 		}
 
 		let results = try await service.resolve(addresses: addresses.map { EthereumAddress($0) })
-
-		return results.map { result in
+		for result in results {
 			if case let .resolved(value) = result.output {
-				return value
+				addressesWithENS[result.address.value.lowercased()] = value
 			}
-
-			return nil
 		}
+
+		print("addresses with ENS: \(addressesWithENS)")
+
+		return addressesWithENS
 	}
 
 	func ens(address: String) async -> String? {

--- a/xmtp-inbox-ios/Utilities/Keystore.swift
+++ b/xmtp-inbox-ios/Utilities/Keystore.swift
@@ -31,7 +31,11 @@ enum Keystore {
 	}
 
 	static func saveKeys(address: String, keys: PrivateKeyBundleV1) throws {
-		try deleteKeys()
+		do {
+			try deleteKeys()
+		} catch {
+			// It's ok, there's no keys to delete
+		}
 
 		UserDefaults.standard.set(address, forKey: addressKey)
 

--- a/xmtp-inbox-ios/Views/ConversationDetailView.swift
+++ b/xmtp-inbox-ios/Views/ConversationDetailView.swift
@@ -36,7 +36,7 @@ struct ConversationDetailView: View {
 	func sendMessage(text: String) async {
 		do {
 			// TODO(elise): Optimistic upload / undo
-			try await conversation.toXMTP(client: client).send(text: text)
+			try await conversation.send(text: text, client: client)
 		} catch {
 			await MainActor.run {
 				self.errorViewModel.showError("Error sending message: \(error)")

--- a/xmtp-inbox-ios/Views/FloatingButton.swift
+++ b/xmtp-inbox-ios/Views/FloatingButton.swift
@@ -8,19 +8,19 @@
 import SwiftUI
 
 struct FloatingButton: View {
-    var icon: Image
-    var action: () -> Void
+	var icon: Image
+	var action: () -> Void
 
-    var body: some View {
-        HapticButton(action: {
-            action()
-        }) {
-            icon
-        }
-        .frame(width: 48, height: 48)
-        .background(Color.actionPrimary)
-        .foregroundColor(.actionPrimaryText)
-        .clipShape(Circle())
-        .shadow(radius: 2, x: 0, y: 1)
-    }
+	var body: some View {
+		HapticButton(action: {
+			action()
+		}) {
+			icon
+		}
+		.frame(width: 48, height: 48)
+		.background(Color.actionPrimary)
+		.foregroundColor(.actionPrimaryText)
+		.clipShape(Circle())
+		.shadow(radius: 2, x: 0, y: 1)
+	}
 }

--- a/xmtp-inbox-ios/Views/HomeView.swift
+++ b/xmtp-inbox-ios/Views/HomeView.swift
@@ -24,16 +24,16 @@ struct HomeView: View {
 			ZStack {
 				Color.backgroundPrimary.edgesIgnoringSafeArea(.all)
 				ConversationListView(client: client)
-                #if DEBUG
-                VStack {
-                    Spacer()
-                    HStack {
-                        Spacer()
-                        FloatingButton(icon: Image("PlusIcon"), action: onNewMessage)
-                            .padding(24)
-                    }
-                }
-                #endif
+				#if DEBUG
+					VStack {
+						Spacer()
+						HStack {
+							Spacer()
+							FloatingButton(icon: Image("PlusIcon"), action: onNewMessage)
+								.padding(24)
+						}
+					}
+				#endif
 			}
 			.navigationBarTitleDisplayMode(.inline)
 			.navigationBarItems(leading: HapticButton {
@@ -64,7 +64,7 @@ struct HomeView: View {
 }
 
 func onNewMessage() {
-    // TODO(elise): Add new message modal
+	// TODO(elise): Add new message modal
 }
 
 struct HomeView_Previews: PreviewProvider {

--- a/xmtp-inbox-ios/Views/MessageListView.swift
+++ b/xmtp-inbox-ios/Views/MessageListView.swift
@@ -68,8 +68,10 @@ struct MessageListView: View {
 
 	func loadMessages() async {
 		do {
+			print("loading messages!")
 			try await messageLoader.load()
 		} catch {
+			print("ERROR LOADING MESSAGSE: \(error)")
 			await MainActor.run {
 				self.errorViewModel.showError("Error loading messages: \(error)")
 			}

--- a/xmtp-inbox-ios/Views/MessageListView.swift
+++ b/xmtp-inbox-ios/Views/MessageListView.swift
@@ -52,13 +52,21 @@ struct MessageListView: View {
 
 	func streamMessages() async {
 		do {
-			for try await message in try conversation.toXMTP(client: client).streamMessages() {
-				let message = try DB.Message.from(message, conversation: conversation)
+			for topic in conversation.topics() {
+				print("Subscribing to topic: \(topic)")
+				Task {
+					for try await xmtpMessage in try topic.toXMTP(client: client).streamMessages() {
+						let message = try DB.Message.from(xmtpMessage, conversation: conversation, topic: topic)
 
-				await MainActor.run {
-					messageLoader.messages.append(message)
+						print("Got a streamed message in \(xmtpMessage)")
+
+						await MainActor.run {
+							messageLoader.messages.append(message)
+						}
+					}
 				}
 			}
+
 		} catch {
 			await MainActor.run {
 				self.errorViewModel.showError("Error streaming messages: \(error)")

--- a/xmtp-inbox-ios/xmtp_inbox_iosApp.swift
+++ b/xmtp-inbox-ios/xmtp_inbox_iosApp.swift
@@ -9,12 +9,15 @@ import SwiftUI
 
 @main
 struct xmtp_inbox_iosApp: App {
+	@AppStorage("dbVersion") var dbVersion: Int = 0
+
 	var body: some Scene {
 		WindowGroup {
 			ContentView()
 				.onAppear {
 					do {
-						try DB.shared.prepare(passphrase: "make this real", reset: true)
+						try DB.shared.prepare(passphrase: "make this real", reset: dbVersion != DB.version)
+						self.dbVersion = DB.version
 					} catch {
 						print("Error preparing DB: \(error)")
 					}

--- a/xmtp-inbox-ios/xmtp_inbox_iosApp.swift
+++ b/xmtp-inbox-ios/xmtp_inbox_iosApp.swift
@@ -14,7 +14,7 @@ struct xmtp_inbox_iosApp: App {
 			ContentView()
 				.onAppear {
 					do {
-						try DB.shared.prepare(passphrase: "make this real", reset: false)
+						try DB.shared.prepare(passphrase: "make this real", reset: true)
 					} catch {
 						print("Error preparing DB: \(error)")
 					}

--- a/xmtp-inbox-iosTests/DBConversationTests.swift
+++ b/xmtp-inbox-iosTests/DBConversationTests.swift
@@ -18,7 +18,7 @@ final class DBConversationTests: XCTestCase {
 	func testCanSaveAConversation() async throws {
 		let date = Date()
 
-		var conversation = DB.Conversation(topic: "m-12345678901234567890", peerAddress: "0xffffffffffffffffffffffffffffffffffffff", createdAt: date)
+		var conversation = DB.Conversation(peerAddress: "0xffffffffffffffffffffffffffffffffffffff", createdAt: date)
 
 		try conversation.save()
 		guard let id = conversation.id else {
@@ -31,7 +31,6 @@ final class DBConversationTests: XCTestCase {
 			return
 		}
 
-		XCTAssertEqual("m-12345678901234567890", loadedConversation.topic)
 		XCTAssertEqual("0xffffffffffffffffffffffffffffffffffffff", loadedConversation.peerAddress)
 		XCTAssertEqual(date.formatted(), loadedConversation.createdAt.formatted())
 	}

--- a/xmtp-inbox-iosTests/KeyStoreTests.swift
+++ b/xmtp-inbox-iosTests/KeyStoreTests.swift
@@ -6,24 +6,24 @@
 //
 
 import Foundation
+import web3
 import XCTest
 import XMTP
-import web3
 @testable import xmtp_inbox_ios
 
 final class KeystoreTests: XCTestCase {
 	func testNoKeysByDefault() throws {
 		XCTAssertEqual(nil, try Keystore.readKeys())
 	}
-	
+
 	func testSavingKeys() throws {
 		let bundleData = Data("0a86030ac00108d79e9be8e23012220a20d530eab5b9c3222b3097e9acd3c3b829d689db599882538f8809083c2ace0af41a920108d79e9be8e23012440a420a40767294d3bff40879bd3fa3aff4bbc41cf0e125674bf59422b9457614d2134e141a905ebaf4ca5d5a98f567f3549f4a40040ab032dc2126293b1d29f18138e9331a430a4104e0c3424f110602e6907a901e29ee240ed2a82ddd29803ce13f6cc9e44a6e2902801d845f8ae0e2804ac4d53765505f266fa6e4a5e2ac1994d149b57c4ed4c92512c00108ed9e9be8e23012220a20734adb910b1d680281dc7eae50197d8a5a37bff1cbc259071bffecc56c6b1ce11a920108ed9e9be8e23012440a420a404cc5e68258c9df37d81eedc6074f9bb265ce989c5452bb8eae84fe335ddbe295744780af7abb6e87395fc3adda2d1adc70fa536dd010468a92836e79e6640bfd1a430a41042f6e32f1accd1d93892dec80200cb20222eb028b4dedacef7ff9c064350ecd05d3dccf4d2ac0fba143bfe392fcf2486f5cda9f8bfa75d0fa1352ef6a913cda69".web3.bytesFromHex!)
 		let bundle = try PrivateKeyBundleV1(serializedData: bundleData)
 		try Keystore.saveKeys(address: "0xd05541222BC89fFE06C9BdA0ad3d1829EDdf5ddb", keys: bundle)
-		
+
 		// make sure we can do this twice without blowing up
 		try Keystore.saveKeys(address: "0xd05541222BC89fFE06C9BdA0ad3d1829EDdf5ddb", keys: bundle)
-		
+
 		let fetchedKeys = try Keystore.readKeys()
 		XCTAssertEqual(fetchedKeys?.identityKey, bundle.identityKey)
 	}

--- a/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
+++ b/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
@@ -5,11 +5,11 @@
 //  Created by Pat on 2/8/23.
 //
 
+import GRDB
 import XCTest
 import XMTP
-import XMTPTestHelpers
-import GRDB
 @testable import xmtp_inbox_ios
+import XMTPTestHelpers
 
 final class ConversationLoaderTests: XCTestCase {
 	override func setUp() async throws {
@@ -19,19 +19,19 @@ final class ConversationLoaderTests: XCTestCase {
 	func testGetsConversations() async throws {
 		let fixtures = await fixtures()
 		let loader = ConversationLoader(client: fixtures.aliceClient)
-		
+
 		var conversations = await loader.conversations
 		XCTAssert(conversations.isEmpty, "had conversations for some reason??")
-		
+
 		let conversation = try await fixtures.aliceClient.conversations.newConversation(with: fixtures.bobClient.address)
 		let clientConversations = try await fixtures.aliceClient.conversations.list()
-		
+
 		XCTAssertEqual(1, clientConversations.count)
-		
+
 		try await loader.load()
 		conversations = await loader.conversations
-		
-		XCTAssertEqual([conversation.topic], conversations.map(\.topic))
+
+		XCTAssertEqual([conversation.topic], conversations.flatMap { $0.topics().map(\.topic) })
 	}
 
 	func testGetsMostRecentMessage() async throws {
@@ -72,5 +72,37 @@ final class ConversationLoaderTests: XCTestCase {
 		conversations = await loader.conversations
 		XCTAssertEqual(loadedConversation.id, conversations[0].id)
 		XCTAssertEqual("2", conversations[0].lastMessage?.body)
+	}
+
+	func testCreatesOneConversationForMultipleTopicsWithSamePeerAddress() async throws {
+		Auth().signOut()
+		try DB.shared.prepare(passphrase: "test", mode: .test, reset: true)
+		let fixtures = await fixtures()
+
+		let aliceConversation = try await fixtures.aliceClient.conversations.newConversation(with: fixtures.bobClient.address)
+		let bobConversation = try await fixtures.bobClient.conversations.newConversation(with: fixtures.aliceClient.address)
+
+		XCTAssertNotEqual(aliceConversation.topic, bobConversation.topic)
+
+		print("ALICE CONVERSATION TOPIC \(aliceConversation.topic)")
+		print("BOB CONVERSATION TOPIC \(bobConversation.topic)")
+
+		try await aliceConversation.send(text: "hi from alice")
+		try await bobConversation.send(text: "hi from bob")
+
+		let loader = ConversationLoader(client: fixtures.aliceClient)
+		try await loader.load()
+
+		let xmtpConversations = try await fixtures.aliceClient.conversations.list()
+		XCTAssertEqual(2, xmtpConversations.count)
+
+		let conversations = await loader.conversations
+		XCTAssertEqual(1, conversations.count)
+
+		let conversation = conversations[0]
+		XCTAssertEqual(1, conversations.count)
+		print("topics \(conversations[0].topics())")
+		XCTAssertEqual(conversation.peerAddress, fixtures.bobClient.address)
+		XCTAssertEqual(2, conversation.topics().count)
 	}
 }

--- a/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
+++ b/xmtp-inbox-iosTests/Loaders/ConversationLoaderTests.swift
@@ -43,8 +43,9 @@ final class ConversationLoaderTests: XCTestCase {
 
 		try await loader.load()
 		var conversations = await loader.conversations
+		let loadedConversation = conversations[0]
 
-		XCTAssertEqual("1", conversations[0].lastMessage?.body)
+		XCTAssertEqual("1", loadedConversation.lastMessage?.body)
 
 		let thePast = Date().addingTimeInterval(-1000)
 		try await DB.shared.queue.write { db in
@@ -64,5 +65,12 @@ final class ConversationLoaderTests: XCTestCase {
 
 		XCTAssertEqual("2", conversations[0].lastMessage?.body)
 
+		try await loader.load()
+		try await loader.load()
+		try await loader.load()
+
+		conversations = await loader.conversations
+		XCTAssertEqual(loadedConversation.id, conversations[0].id)
+		XCTAssertEqual("2", conversations[0].lastMessage?.body)
 	}
 }


### PR DESCRIPTION
Adds a new model `ConversationTopic` so we can keep track of different topics for the same peer address. We're not showing different contexts yet, but this lays the groundwork to do so.

I think some of this logic could be moved over to the SDK, but I'd rather see how this approach settles over here first.

cc https://github.com/xmtp-labs/xmtp-inbox-ios/issues/42