### PR TITLE
Get metamask redirect working when you have the app installed

### DIFF
--- a/xmtp-inbox-ios/Info.plist
+++ b/xmtp-inbox-ios/Info.plist
@@ -9,6 +9,7 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>wc</string>
+		<string>metamask</string>
 	</array>
 </dict>
 </plist>

--- a/xmtp-inbox-ios/Views/SplashView.swift
+++ b/xmtp-inbox-ios/Views/SplashView.swift
@@ -170,7 +170,24 @@ struct WalletConnectionWebview: UIViewRepresentable {
 			}
 		}
 
-		func webView(_: WKWebView, decidePolicyFor _: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+		func webView(_: WKWebView, decidePolicyFor action: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+			guard let url = action.request.url else {
+				decisionHandler(.allow)
+				return
+			}
+
+			if url.absoluteString.contains("?"),
+			   url.host() == "metamask.app.link",
+			   let query = url.query(percentEncoded: false),
+			   let deepLink = URL(string: "metamask://wc/wc?\(query)")
+			{
+				if UIApplication.shared.canOpenURL(deepLink) {
+					UIApplication.shared.open(deepLink)
+					decisionHandler(.cancel)
+					return
+				}
+			}
+
 			decisionHandler(.allow)
 		}
 	}


### PR DESCRIPTION
This PR listens to see if we're trying to open the metamask deep link in the webview and if so, just tries to open metamask. Prior to this, tapping the metamask button would either do nothing or take you to the app store.

You currently have to bounce between the apps manually, but this at least unbreaks the flow for metamask users who couldn't auth at all before.